### PR TITLE
[API] Dissociate User ID from Auth0 User ID.

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -14,7 +14,7 @@
 		"start:watch": "nodemon",
 		"start:watch:dev": "nodemon",
 		"swagger": "tsoa spec-and-routes",
-		"test": "NODE_ENV=test mocha -r ts-node/register --timeout 20000 --exit ./tests/*.test.ts",
+		"test": "NODE_ENV=test mocha -r ts-node/register --timeout 30000 --exit ./tests/*.test.ts",
 		"coverage": "nyc npm run test"
 	},
 	"keywords": [],

--- a/api/src/config/swagger.json
+++ b/api/src/config/swagger.json
@@ -271,13 +271,16 @@
 					"title": {
 						"type": "string"
 					},
+					"description": {
+						"type": "string"
+					},
 					"closureDate": {
 						"type": "string",
 						"format": "date-time"
 					},
 					"ownersIds": {
 						"items": {
-							"type": "string"
+							"$ref": "#/components/schemas/UUID"
 						},
 						"type": "array"
 					},
@@ -286,7 +289,7 @@
 					},
 					"grantedUsersIds": {
 						"items": {
-							"type": "string"
+							"$ref": "#/components/schemas/UUID"
 						},
 						"type": "array"
 					}
@@ -313,18 +316,24 @@
 					},
 					"ownersIds": {
 						"items": {
-							"type": "string"
+							"$ref": "#/components/schemas/UUID"
 						},
 						"type": "array"
 					},
 					"isShared": {
 						"type": "boolean"
+					},
+					"grantedUsersIds": {
+						"items": {
+							"$ref": "#/components/schemas/UUID"
+						},
+						"type": "array"
 					}
 				},
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"ListDTO": {
+			"Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_": {
 				"properties": {
 					"id": {
 						"$ref": "#/components/schemas/UUID"
@@ -341,12 +350,18 @@
 					},
 					"ownersIds": {
 						"items": {
-							"type": "string"
+							"$ref": "#/components/schemas/UUID"
 						},
 						"type": "array"
 					},
 					"isShared": {
 						"type": "boolean"
+					},
+					"grantedUsersIds": {
+						"items": {
+							"$ref": "#/components/schemas/UUID"
+						},
+						"type": "array"
 					}
 				},
 				"required": [
@@ -357,7 +372,10 @@
 					"isShared"
 				],
 				"type": "object",
-				"additionalProperties": false
+				"description": "From T, pick a set of properties whose keys are in the union K"
+			},
+			"ListDTO": {
+				"$ref": "#/components/schemas/Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_"
 			},
 			"SelectKindList": {
 				"description": "List Selection Kind",
@@ -371,7 +389,7 @@
 			"UserIdDTO": {
 				"properties": {
 					"id": {
-						"type": "string"
+						"$ref": "#/components/schemas/UUID"
 					}
 				},
 				"required": [
@@ -388,7 +406,7 @@
 			},
 			"CreateUserDTO": {
 				"properties": {
-					"id": {
+					"auth0Id": {
 						"type": "string"
 					},
 					"email": {
@@ -399,7 +417,7 @@
 					}
 				},
 				"required": [
-					"id",
+					"auth0Id",
 					"email",
 					"displayName"
 				],

--- a/api/src/config/swagger.json
+++ b/api/src/config/swagger.json
@@ -310,6 +310,9 @@
 					"sharingCode": {
 						"$ref": "#/components/schemas/UUID"
 					},
+					"description": {
+						"type": "string"
+					},
 					"closureDate": {
 						"type": "string",
 						"format": "date-time"
@@ -333,7 +336,7 @@
 				"type": "object",
 				"description": "Make all properties in T optional"
 			},
-			"Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_": {
+			"Pick_List.-or-id-or-description-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_": {
 				"properties": {
 					"id": {
 						"$ref": "#/components/schemas/UUID"
@@ -343,6 +346,9 @@
 					},
 					"sharingCode": {
 						"$ref": "#/components/schemas/UUID"
+					},
+					"description": {
+						"type": "string"
 					},
 					"closureDate": {
 						"type": "string",
@@ -375,7 +381,7 @@
 				"description": "From T, pick a set of properties whose keys are in the union K"
 			},
 			"ListDTO": {
-				"$ref": "#/components/schemas/Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_"
+				"$ref": "#/components/schemas/Pick_List.-or-id-or-description-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_"
 			},
 			"SelectKindList": {
 				"description": "List Selection Kind",

--- a/api/src/controllers/GiftController.ts
+++ b/api/src/controllers/GiftController.ts
@@ -44,7 +44,7 @@ export class GiftController extends Controller {
 		@Path() listId: UUID,
 		@Body() body: CreateGiftDTO
 	): Promise<GiftIdDTO> {
-		if (!(await ListService.listOwners(listId)).includes(request.userId)) {
+		if (!(await ListService.ownersAuth0Ids(listId)).includes(request.userId)) {
 			throw new UnauthorizedError();
 		}
 		const list: List = await ListService.get(listId);
@@ -72,7 +72,7 @@ export class GiftController extends Controller {
 		@Body() body: Partial<EditGiftDTO>
 	): Promise<void> {
 		if (
-			!(await ListService.listOwners(listId)).includes(request.userId) ||
+			!(await ListService.ownersAuth0Ids(listId)).includes(request.userId) ||
 			!(await GiftService.checkGiftOfList(listId, giftId))
 		) {
 			throw new UnauthorizedError();
@@ -98,12 +98,12 @@ export class GiftController extends Controller {
 		@Path() giftId: UUID
 	): Promise<void> {
 		if (
-			!(await ListService.listOwners(listId)).includes(request.userId) ||
+			!(await ListService.ownersAuth0Ids(listId)).includes(request.userId) ||
 			!(await GiftService.checkGiftOfList(listId, giftId))
 		) {
 			throw new UnauthorizedError();
 		}
-		this.quickDelete(giftId);
+		await this.quickDelete(giftId);
 	}
 
 	async quickDelete(giftId: UUID): Promise<void> {
@@ -124,8 +124,8 @@ export class GiftController extends Controller {
 		@Path() listId: UUID
 	): Promise<GiftDTO[] | GiftDTOForOwner[]> {
 		let gifts: Gift[] = [];
-		const isOwner: boolean = (await ListService.listOwners(listId)).includes(request.userId);
-		if ((await ListService.listGrantedUsers(listId)).includes(request.userId)) {
+		const isOwner: boolean = (await ListService.ownersAuth0Ids(listId)).includes(request.userId);
+		if ((await ListService.grantedUsersAuth0Ids(listId)).includes(request.userId)) {
 			gifts = await ListService.getListGifts(listId, false);
 		} else if (isOwner) {
 			gifts = await ListService.getListGifts(listId, true);
@@ -155,9 +155,9 @@ export class GiftController extends Controller {
 		@Path() listId: UUID,
 		@Path() giftId: UUID
 	): Promise<GiftDTO | GiftDTOForOwner> {
-		const isOwner: boolean = (await ListService.listOwners(listId)).includes(request.userId);
+		const isOwner: boolean = (await ListService.ownersAuth0Ids(listId)).includes(request.userId);
 		if (
-			(!isOwner && !(await ListService.listGrantedUsers(listId)).includes(request.userId)) ||
+			(!isOwner && !(await ListService.grantedUsersAuth0Ids(listId)).includes(request.userId)) ||
 			!(await GiftService.checkGiftOfList(listId, giftId))
 		) {
 			throw new UnauthorizedError();
@@ -264,8 +264,8 @@ export class GiftController extends Controller {
 		@Path() giftId: UUID
 	): Promise<void> {
 		if (
-			((await ListService.listOwners(listId)).includes(request.userId) &&
-				!(await ListService.listGrantedUsers(listId)).includes(request.userId)) ||
+			((await ListService.ownersAuth0Ids(listId)).includes(request.userId) &&
+				!(await ListService.grantedUsersAuth0Ids(listId)).includes(request.userId)) ||
 			!(await GiftService.checkGiftOfList(listId, giftId))
 		) {
 			throw new UnauthorizedError();
@@ -291,8 +291,8 @@ export class GiftController extends Controller {
 		@Path() giftId: UUID
 	): Promise<void> {
 		if (
-			(await ListService.listOwners(listId)).includes(request.userId) ||
-			!(await ListService.listGrantedUsers(listId)).includes(request.userId) ||
+			(await ListService.ownersAuth0Ids(listId)).includes(request.userId) ||
+			!(await ListService.grantedUsersAuth0Ids(listId)).includes(request.userId) ||
 			!(await GiftService.checkGiftOfList(listId, giftId))
 		) {
 			throw new UnauthorizedError();

--- a/api/src/controllers/UserLoggedController.ts
+++ b/api/src/controllers/UserLoggedController.ts
@@ -30,7 +30,7 @@ export class UserLoggedController extends Controller {
 	@SuccessResponse(200, "Success response")
 	@Get()
 	async get(@Request() request: ERequest): Promise<UserDTO> {
-		const user: User = await UserService.getById(request.userId);
+		const user: User = await UserService.getByAuth0Id(request.userId);
 		const { id, createdDate, ...rest } = user;
 		return rest;
 	}

--- a/api/src/controllers/UserManagementController.ts
+++ b/api/src/controllers/UserManagementController.ts
@@ -53,7 +53,7 @@ export class UserManagementController extends Controller {
 	@Security("auth0")
 	@SuccessResponse(204)
 	@Response<ValidateErrorJSON>(422, "If body or request param type is violated")
-	@Delete("admin/{userId}")
+	@Delete("admin/{userAuth0Id}")
 	@Hidden() // TODO: Remove Hidden and add administration capabilities
 	async delete(@Path() userAuth0Id: string): Promise<void> {
 		await this.quickDelete(userAuth0Id);

--- a/api/src/dto/lists.ts
+++ b/api/src/dto/lists.ts
@@ -9,9 +9,11 @@ export interface CreateListDTO
 		>
 	> {}
 export interface ListIdDTO extends Expand<Pick<List, "id">> {}
-export interface ListDTO
-	extends Expand<
-		Pick<List, "id" | "title" | "isShared" | "sharingCode" | "closureDate" | "ownersIds">
-	> {}
+
+// TODO: Understand why Expand make tsoa going to timeout
+export type ListDTO = Pick<
+	List,
+	"id" | "title" | "isShared" | "sharingCode" | "closureDate" | "ownersIds" | "grantedUsersIds"
+>;
 
 export interface EditListDTO extends Expand<Omit<ListDTO, "id">> {}

--- a/api/src/dto/lists.ts
+++ b/api/src/dto/lists.ts
@@ -13,7 +13,14 @@ export interface ListIdDTO extends Expand<Pick<List, "id">> {}
 // TODO: Understand why Expand make tsoa going to timeout
 export type ListDTO = Pick<
 	List,
-	"id" | "title" | "isShared" | "sharingCode" | "closureDate" | "ownersIds" | "grantedUsersIds"
+	| "id"
+	| "description"
+	| "title"
+	| "isShared"
+	| "sharingCode"
+	| "closureDate"
+	| "ownersIds"
+	| "grantedUsersIds"
 >;
 
 export interface EditListDTO extends Expand<Omit<ListDTO, "id">> {}

--- a/api/src/dto/users.ts
+++ b/api/src/dto/users.ts
@@ -2,6 +2,6 @@ import User from "../models/User";
 import Expand from "./expand";
 
 export interface CreateUserDTO
-	extends Expand<Omit<User, "friends" | "lists" | "friendLists" | "createdDate">> {}
+	extends Expand<Omit<User, "id" | "friends" | "lists" | "friendLists" | "createdDate">> {}
 export interface UserIdDTO extends Expand<Pick<User, "id">> {}
 export interface UserDTO extends Expand<Pick<User, "displayName" | "email">> {}

--- a/api/src/models/List.ts
+++ b/api/src/models/List.ts
@@ -23,6 +23,9 @@ export class List {
 	public title!: string;
 
 	@Column({ nullable: true })
+	public description?: string;
+
+	@Column({ nullable: true })
 	public closureDate?: Date;
 
 	@ManyToMany(() => User, (user) => user.lists)
@@ -30,7 +33,7 @@ export class List {
 	public owners!: User[];
 
 	@RelationId((list: List) => list.owners)
-	public ownersIds!: string[];
+	public ownersIds!: UUID[];
 
 	@Column({ default: false })
 	public isShared!: boolean;
@@ -43,7 +46,7 @@ export class List {
 	public grantedUsers?: User[];
 
 	@RelationId((list: List) => list.grantedUsers)
-	public grantedUsersIds?: string[];
+	public grantedUsersIds?: UUID[];
 
 	@OneToMany(() => Gift, (gift) => gift.list)
 	public gifts?: Gift[];

--- a/api/src/models/User.ts
+++ b/api/src/models/User.ts
@@ -1,12 +1,23 @@
-import { Column, CreateDateColumn, Entity, JoinTable, ManyToMany, PrimaryColumn } from "typeorm";
+import {
+	Column,
+	CreateDateColumn,
+	Entity,
+	JoinTable,
+	ManyToMany,
+	PrimaryGeneratedColumn,
+} from "typeorm";
 
 import { email } from "../types/email";
+import { UUID } from "../types/UUID";
 import List from "./List";
 
 @Entity("User", { orderBy: { createdDate: "ASC" } })
 export class User {
-	@PrimaryColumn()
-	public id!: string;
+	@PrimaryGeneratedColumn("uuid")
+	public id!: UUID;
+
+	@Column()
+	public auth0Id!: string;
 
 	@Column()
 	public email!: email;

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -122,17 +122,17 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_EditListDTO_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"sharingCode":{"ref":"UUID"},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}},"isShared":{"dataType":"boolean"},"grantedUsersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"sharingCode":{"ref":"UUID"},"description":{"dataType":"string"},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}},"isShared":{"dataType":"boolean"},"grantedUsersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    "Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_": {
+    "Pick_List.-or-id-or-description-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"UUID","required":true},"title":{"dataType":"string","required":true},"sharingCode":{"ref":"UUID","required":true},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"},"required":true},"isShared":{"dataType":"boolean","required":true},"grantedUsersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"UUID","required":true},"title":{"dataType":"string","required":true},"sharingCode":{"ref":"UUID","required":true},"description":{"dataType":"string"},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"},"required":true},"isShared":{"dataType":"boolean","required":true},"grantedUsersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ListDTO": {
         "dataType": "refAlias",
-        "type": {"ref":"Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_","validators":{}},
+        "type": {"ref":"Pick_List.-or-id-or-description-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "SelectKindList": {
@@ -697,12 +697,12 @@ export function RegisterRoutes(app: express.Router) {
             }
         });
         // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-        app.delete('/users/admin/:userId',
+        app.delete('/users/admin/:userAuth0Id',
             authenticateMiddleware([{"auth0":[]}]),
 
             function UserManagementController_delete(request: any, response: any, next: any) {
             const args = {
-                    userId: {"in":"path","name":"userId","required":true,"dataType":"string"},
+                    userAuth0Id: {"in":"path","name":"userAuth0Id","required":true,"dataType":"string"},
             };
 
             // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa

--- a/api/src/routes.ts
+++ b/api/src/routes.ts
@@ -111,30 +111,28 @@ const models: TsoaRoute.Models = {
         "dataType": "refObject",
         "properties": {
             "title": {"dataType":"string","required":true},
+            "description": {"dataType":"string"},
             "closureDate": {"dataType":"datetime"},
-            "ownersIds": {"dataType":"array","array":{"dataType":"string"},"required":true},
+            "ownersIds": {"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"},"required":true},
             "isShared": {"dataType":"boolean","required":true},
-            "grantedUsersIds": {"dataType":"array","array":{"dataType":"string"}},
+            "grantedUsersIds": {"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}},
         },
         "additionalProperties": false,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "Partial_EditListDTO_": {
         "dataType": "refAlias",
-        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"sharingCode":{"ref":"UUID"},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"string"}},"isShared":{"dataType":"boolean"}},"validators":{}},
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"title":{"dataType":"string"},"sharingCode":{"ref":"UUID"},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}},"isShared":{"dataType":"boolean"},"grantedUsersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}}},"validators":{}},
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    "Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_": {
+        "dataType": "refAlias",
+        "type": {"dataType":"nestedObjectLiteral","nestedProperties":{"id":{"ref":"UUID","required":true},"title":{"dataType":"string","required":true},"sharingCode":{"ref":"UUID","required":true},"closureDate":{"dataType":"datetime"},"ownersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"},"required":true},"isShared":{"dataType":"boolean","required":true},"grantedUsersIds":{"dataType":"array","array":{"dataType":"refAlias","ref":"UUID"}}},"validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "ListDTO": {
-        "dataType": "refObject",
-        "properties": {
-            "id": {"ref":"UUID","required":true},
-            "title": {"dataType":"string","required":true},
-            "sharingCode": {"ref":"UUID","required":true},
-            "closureDate": {"dataType":"datetime"},
-            "ownersIds": {"dataType":"array","array":{"dataType":"string"},"required":true},
-            "isShared": {"dataType":"boolean","required":true},
-        },
-        "additionalProperties": false,
+        "dataType": "refAlias",
+        "type": {"ref":"Pick_List.id-or-title-or-isShared-or-sharingCode-or-closureDate-or-ownersIds-or-grantedUsersIds_","validators":{}},
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     "SelectKindList": {
@@ -145,7 +143,7 @@ const models: TsoaRoute.Models = {
     "UserIdDTO": {
         "dataType": "refObject",
         "properties": {
-            "id": {"dataType":"string","required":true},
+            "id": {"ref":"UUID","required":true},
         },
         "additionalProperties": false,
     },
@@ -158,7 +156,7 @@ const models: TsoaRoute.Models = {
     "CreateUserDTO": {
         "dataType": "refObject",
         "properties": {
-            "id": {"dataType":"string","required":true},
+            "auth0Id": {"dataType":"string","required":true},
             "email": {"ref":"email","required":true},
             "displayName": {"dataType":"string","required":true},
         },

--- a/api/src/services/ListService.ts
+++ b/api/src/services/ListService.ts
@@ -45,13 +45,13 @@ class ListService {
 	 * @param {UUID} userId id of user which ask, uuid v4 formatted
 	 * @returns {Promise<List>} the forgotten list
 	 */
-	static async forget(listId: UUID, userId: UUID): Promise<List> {
+	static async forget(listId: UUID, userAuth0Id: UUID): Promise<List> {
 		const listRepository: Repository<List> = getRepository(List);
 		const list: List = await listRepository.findOneOrFail(listId, {
 			relations: ["owners", "grantedUsers"],
 		});
-		list.owners = list.owners.filter((owner) => owner.id !== userId);
-		list.grantedUsers = (list.grantedUsers || []).filter((user) => user.id !== userId);
+		list.owners = list.owners.filter((owner) => owner.auth0Id !== userAuth0Id);
+		list.grantedUsers = (list.grantedUsers || []).filter((user) => user.auth0Id !== userAuth0Id);
 		return await listRepository.save(list);
 	}
 
@@ -101,10 +101,10 @@ class ListService {
 	 * @param {UUID} listId id of list, uuid v4 formatted
 	 * @returns {Promise<UUID[]>} the listId owners
 	 */
-	static async listOwners(listId: UUID): Promise<UUID[]> {
+	static async ownersAuth0Ids(listId: UUID): Promise<UUID[]> {
 		const listRepository: Repository<List> = getRepository(List);
 		const list: List = await listRepository.findOneOrFail(listId, { relations: ["owners"] });
-		return list.owners.map((u) => u.id);
+		return list.owners.map((u) => u.auth0Id);
 	}
 
 	/**
@@ -112,12 +112,12 @@ class ListService {
 	 * @param {UUID} listId id of list, uuid v4 formatted
 	 * @returns {Promise<UUID[]>} the listId granted users
 	 */
-	static async listGrantedUsers(listId: UUID): Promise<UUID[]> {
+	static async grantedUsersAuth0Ids(listId: UUID): Promise<UUID[]> {
 		const listRepository: Repository<List> = getRepository(List);
 		const list: List = await listRepository.findOneOrFail(listId, {
 			relations: ["grantedUsers"],
 		});
-		return (list.grantedUsers || []).map((u) => u.id);
+		return (list.grantedUsers || []).map((u) => u.auth0Id);
 	}
 
 	/**

--- a/api/src/services/UserService.ts
+++ b/api/src/services/UserService.ts
@@ -4,6 +4,7 @@ import List from "../models/List";
 import User from "../models/User";
 import { email } from "../types/email";
 import { SelectKindList } from "../types/SelectKindList";
+import { UUID } from "../types/UUID";
 
 class UserService {
 	/**
@@ -20,23 +21,23 @@ class UserService {
 
 	/**
 	 * Edit user properties.
-	 * @param {string} userId id of user to update
+	 * @param {string} userAuth0Id id of user to update
 	 * @param {Partial<User>} userNewProps new props of user to apply
 	 * @returns {Promise<UpdateResult>}
 	 */
-	static async edit(userId: string, userNewProps: Partial<User>): Promise<UpdateResult> {
+	static async edit(userAuth0Id: string, userNewProps: Partial<User>): Promise<UpdateResult> {
 		const userRepository: Repository<User> = getRepository(User);
-		return await userRepository.update(userId, { ...userNewProps });
+		return await userRepository.update({ auth0Id: userAuth0Id }, { ...userNewProps });
 	}
 
 	/**
 	 * Delete a user from Database.
-	 * @param {string} userId id of user to delete
+	 * @param {string} userAuth0Id id of user to delete
 	 * @returns {Promise<DeleteResult>}
 	 */
-	static async delete(userId: string): Promise<DeleteResult> {
+	static async delete(userAuth0Id: string): Promise<DeleteResult> {
 		const userRepository: Repository<User> = getRepository(User);
-		return await userRepository.delete(userId);
+		return await userRepository.delete({ auth0Id: userAuth0Id });
 	}
 
 	/**
@@ -50,12 +51,12 @@ class UserService {
 
 	/**
 	 * Return a user from Database.
-	 * @param {string} userId id of user to get
+	 * @param {string} userAuth0Id id of user to get
 	 * @returns {Promise<User[]>} The user matching the userId parameter
 	 */
-	static async getById(userId: string): Promise<User> {
+	static async getByAuth0Id(userAuth0Id: string): Promise<User> {
 		const userRepository: Repository<User> = getRepository(User);
-		return await userRepository.findOneOrFail(userId);
+		return await userRepository.findOneOrFail({ where: { auth0Id: userAuth0Id } });
 	}
 
 	/**
@@ -70,27 +71,28 @@ class UserService {
 
 	/**
 	 * Return a user from Database.
-	 * @param {string} userId id of user to get
+	 * @param {UUID[]} userIds id of user to get
 	 * @returns {Promise<User[]>} The user matching the userId parameter
 	 */
-	static async getMany(userIds: string[]): Promise<User[]> {
+	static async getMany(userIds: UUID[]): Promise<User[]> {
 		const userRepository: Repository<User> = getRepository(User);
 		return await userRepository.findByIds(userIds);
 	}
 
 	/**
 	 * Returns all user lists.
-	 * @param {string} userId id of user which owns the list
+	 * @param {string} userAuth0Id id of user which owns the list
 	 * @param {SelectKindList} select filter tag to return "all" lists, "owns" or "granted" ones only
 	 * @returns {Promise<List[]>} the userId lists
 	 */
 	static async getUserLists(
-		userId: string,
+		userAuth0Id: string,
 		select: SelectKindList,
 		reallyAll: boolean = false
 	): Promise<List[]> {
 		const userRepository: Repository<User> = getRepository(User);
-		const user: User = await userRepository.findOneOrFail(userId, {
+		const user: User = await userRepository.findOneOrFail({
+			where: { auth0Id: userAuth0Id },
 			relations: ["lists", "friendLists", "lists.owners", "friendLists.owners"],
 		});
 		let res: List[] = [];

--- a/api/tests/01_users/delete_me.test.ts
+++ b/api/tests/01_users/delete_me.test.ts
@@ -10,10 +10,9 @@ export default function suite() {
 	it("Returns 204 and user is no more present", async () => {
 		const { id: id1, createdDate: createdDate1, ...user1 } = User1;
 		const { id: id2, createdDate: createdDate2, ...user2 } = User2;
-		const { id: idNewUser, ...newUserTest } = NewUserTest;
 		const response = await del(Url_UserDeleteMe());
 		expectError(response, 404, "Resource not found"); // Test users are not added to Auth0 DB
 		const list = await get(Url_UserGetAll());
-		expect(list).to.have.property("body").to.have.deep.members([user1, user2, newUserTest]);
+		expect(list).to.have.property("body").to.have.deep.members([user1, user2, NewUserTest]);
 	});
 }

--- a/api/tests/01_users/get_all.test.ts
+++ b/api/tests/01_users/get_all.test.ts
@@ -1,20 +1,19 @@
 import { expect } from "chai";
 
-import { NewUserTest, Url_UserGetAll, UserTest } from "../global";
+import { NewUserTest, Url_UserGetAll } from "../global";
 import { get } from "../helpers/crud";
 import { expect200 } from "../helpers/success";
-import { User1, User2 } from "../seeder/users.seed";
+import { User1, User2, UserTest } from "../seeder/users.seed";
 
 export default function suite() {
 	it("Returns 200 with all users as an array", async () => {
 		const { id: id1, createdDate: createdDate1, ...user1 } = User1;
 		const { id: id2, createdDate: createdDate2, ...user2 } = User2;
-		const { id: idTest, ...userTest } = UserTest;
-		const { id: idNewUser, ...newUserTest } = NewUserTest;
+		const { id: idTest, createdDate: createdDateTest, ...userTest } = UserTest;
 		const response = await get(Url_UserGetAll());
 		expect200(response);
 		expect(response)
 			.to.have.property("body")
-			.to.have.deep.members([user1, user2, userTest, newUserTest]);
+			.to.have.deep.members([user1, user2, userTest, NewUserTest]);
 	});
 }

--- a/api/tests/01_users/get_me.test.ts
+++ b/api/tests/01_users/get_me.test.ts
@@ -1,13 +1,13 @@
 import { expect } from "chai";
 
-import { UserTest } from "../global";
 import { Url_UserGetMe } from "../global/urls";
 import { get } from "../helpers/crud";
 import { expect200 } from "../helpers/success";
+import { UserTest } from "../seeder/users.seed";
 
 export default function suite() {
 	it("Returns 200 with user informations", async () => {
-		const { id, ...user } = UserTest;
+		const { id, createdDate, ...user } = UserTest;
 		const response = await get(Url_UserGetMe());
 		expect200(response);
 		expect(response).to.have.property("body").to.eql(user);

--- a/api/tests/01_users/post.test.ts
+++ b/api/tests/01_users/post.test.ts
@@ -1,14 +1,15 @@
 import { expect } from "chai";
 
-import { NewUserTest, Url_UserPost, UserTest } from "../global";
+import { GlobalVar, NewUserTest, Url_UserPost } from "../global";
 import { post } from "../helpers/crud";
 import { expectValidationFailed } from "../helpers/error";
 import { expect200 } from "../helpers/success";
-import { User1 } from "../seeder/users.seed";
+import { User1, UserTest } from "../seeder/users.seed";
 
 export default function suite() {
 	it("Returns 200 with ID if user already exist", async () => {
-		const response = await post(Url_UserPost(), UserTest);
+		const { id, createdDate, friends, friendLists, lists, ...userTest } = UserTest;
+		const response = await post(Url_UserPost(), userTest);
 		expect200(response);
 		expect(response).to.have.property("body").to.have.property("id").to.be.a.string;
 	});
@@ -16,6 +17,7 @@ export default function suite() {
 		const response = await post(Url_UserPost(), NewUserTest);
 		expect200(response);
 		expect(response).to.have.property("body").to.have.property("id").to.be.a.string;
+		GlobalVar.NewUserTest_Id = response.body.id;
 	});
 	it("Returns 422, with validation error, if email is malformed", async () => {
 		const responses = [
@@ -27,8 +29,8 @@ export default function suite() {
 	it("Returns 422, with validation error, if one of fields is empty", async () => {
 		const responses = [
 			await post(Url_UserPost(), { displayName: "TestUser2", email: "test@test" }),
-			await post(Url_UserPost(), { id: "auth0|000000000000", email: "test@test" }),
-			await post(Url_UserPost(), { id: "auth0|000000000000", displayName: "TestUser2" }),
+			await post(Url_UserPost(), { auth0Id: "auth0|000000000000", email: "test@test" }),
+			await post(Url_UserPost(), { auth0Id: "auth0|000000000000", displayName: "TestUser2" }),
 		];
 		responses.forEach((response) => expectValidationFailed(response));
 	});

--- a/api/tests/01_users/put_me.test.ts
+++ b/api/tests/01_users/put_me.test.ts
@@ -1,13 +1,14 @@
 import { expect } from "chai";
 
-import { Url_UserGetMe, Url_UserPutMe, UserTest } from "../global";
+import { Url_UserGetMe, Url_UserPutMe } from "../global";
 import { get, put } from "../helpers/crud";
 import { expect204 } from "../helpers/success";
+import { UserTest } from "../seeder/users.seed";
 
 export default function suite() {
 	it("Returns 204, user informations are changed", async () => {
 		const origMail: string = UserTest.email;
-		const { id, ...user } = UserTest;
+		const { id, createdDate, ...user } = UserTest;
 		const response = await put(Url_UserPutMe(), { email: "new@new.fr" });
 		expect204(response);
 		const changedUser = await get(Url_UserGetMe());

--- a/api/tests/02_lists/invite.test.ts
+++ b/api/tests/02_lists/invite.test.ts
@@ -1,11 +1,12 @@
 import { expect } from "chai";
 import { v4 as uuidv4 } from "uuid";
 
-import { Url_ListGetOne, Url_ListInvite, UserTest } from "../global";
+import { Url_ListGetOne, Url_ListInvite } from "../global";
 import { get, put } from "../helpers/crud";
 import { expectError, expectValidationFailed } from "../helpers/error";
 import { expect204 } from "../helpers/success";
 import { ListInvited, ListOwned } from "../seeder/lists.seed";
+import { UserTest } from "../seeder/users.seed";
 import { castAsListDTO } from "./cast";
 
 export default function suite() {

--- a/api/tests/02_lists/invite.test.ts
+++ b/api/tests/02_lists/invite.test.ts
@@ -20,12 +20,17 @@ export default function suite() {
 		const response = await put(Url_ListInvite(ListInvited.sharingCode), {});
 		expect204(response);
 		const changedList = await get(Url_ListGetOne(ListInvited.id));
+		const { ownersIds, ...rest } = castAsListDTO(ListInvited);
 		expect(changedList)
 			.to.have.property("body")
-			.to.eql({
-				...castAsListDTO(ListInvited),
+			.to.deep.include({
+				...rest,
 				grantedUsersIds: [UserTest.id],
 			});
+		expect(changedList)
+			.to.have.property("body")
+			.to.have.nested.property("ownersIds")
+			.to.have.members(ownersIds);
 	});
 	it("Returns 404, with UnvalidSharingCode error, if sharing code does not exist", async () => {
 		const response = await put(Url_ListInvite(uuidv4()));

--- a/api/tests/after.test.ts
+++ b/api/tests/after.test.ts
@@ -5,7 +5,7 @@ import { del } from "./helpers/crud";
 import { User1, User2 } from "./seeder/users.seed";
 
 after(async () => {
-	await del(Url_UserDelete(User1.id));
-	await del(Url_UserDelete(User2.id));
-	await del(Url_UserDelete(NewUserTest.id));
+	await del(Url_UserDelete(User1.auth0Id));
+	await del(Url_UserDelete(User2.auth0Id));
+	await del(Url_UserDelete(NewUserTest.auth0Id));
 });

--- a/api/tests/global/objects.ts
+++ b/api/tests/global/objects.ts
@@ -3,20 +3,14 @@ import { config } from "dotenv";
 import { CreateGiftDTO } from "../../src/dto/gifts";
 import { CreateListDTO } from "../../src/dto/lists";
 import { CreateUserDTO } from "../../src/dto/users";
-import { User1 } from "../seeder/users.seed";
+import { User1, UserTest } from "../seeder/users.seed";
 
 config({ path: process.env.NODE_ENV == "dev" ? ".env.local" : ".env.test" });
 
 export const NewUserTest: CreateUserDTO = {
-	id: "newUserId",
+	auth0Id: "newUserId",
 	email: "newUserMail@test.fr",
 	displayName: "Test NewUser",
-};
-
-export const UserTest: CreateUserDTO = {
-	id: process.env.AUTH0_CLIENT_ID + "@clients",
-	email: "testuser@test.fr",
-	displayName: "Test User",
 };
 
 export const ListTest: CreateListDTO = {

--- a/api/tests/global/variables.ts
+++ b/api/tests/global/variables.ts
@@ -1,6 +1,8 @@
 export default class {
 	public static Token: string = "";
 
+	public static NewUserTest_Id: string = "";
+
 	public static ListTest_Id: string = "";
 	public static ListTest_SharingCode: string = "";
 	public static ListTestWithGranted_Id: string = "";

--- a/api/tests/seeder/gifts.seed.ts
+++ b/api/tests/seeder/gifts.seed.ts
@@ -1,6 +1,7 @@
 import { v4 as uuidv4 } from "uuid";
 
 import Gift from "../../src/models/Gift";
+import { getDateFromNow } from "./helper";
 import { ListGranted, ListOwned, ListUnauthorized } from "./lists.seed";
 
 export const Gift1: Gift = {
@@ -12,8 +13,8 @@ export const Gift1: Gift = {
 	isHidden: false,
 	listId: ListOwned.id,
 	list: ListOwned,
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-5),
+	updatedDate: getDateFromNow(-5),
 };
 
 export const Gift2: Gift = {
@@ -25,8 +26,8 @@ export const Gift2: Gift = {
 	isHidden: true,
 	listId: ListOwned.id,
 	list: ListOwned,
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-4),
+	updatedDate: getDateFromNow(-4),
 };
 
 export const Gift3: Gift = {
@@ -38,8 +39,8 @@ export const Gift3: Gift = {
 	isHidden: false,
 	listId: ListGranted.id,
 	list: ListGranted,
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-3),
+	updatedDate: getDateFromNow(-3),
 };
 
 export const Gift4: Gift = {
@@ -51,8 +52,8 @@ export const Gift4: Gift = {
 	isHidden: true,
 	listId: ListGranted.id,
 	list: ListGranted,
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-2),
+	updatedDate: getDateFromNow(-2),
 };
 
 export const Gift5: Gift = {
@@ -64,6 +65,6 @@ export const Gift5: Gift = {
 	isHidden: false,
 	listId: ListUnauthorized.id,
 	list: ListUnauthorized,
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-1),
+	updatedDate: getDateFromNow(-1),
 };

--- a/api/tests/seeder/helper.ts
+++ b/api/tests/seeder/helper.ts
@@ -1,0 +1,5 @@
+export function getDateFromNow(days: number = 0): Date {
+	const current = new Date();
+	current.setDate(current.getDate() + days);
+	return current;
+}

--- a/api/tests/seeder/lists.seed.ts
+++ b/api/tests/seeder/lists.seed.ts
@@ -1,19 +1,20 @@
 import { v4 as uuidv4 } from "uuid";
 
 import List from "../../src/models/List";
-import { UserTest } from "../global";
-import { User1, User2 } from "./users.seed";
+import { getDateFromNow } from "./helper";
+import { User1, User2, UserTest } from "./users.seed";
 
 export const ListOwned: List = {
 	id: uuidv4(),
 	title: "TestList1",
+	description: "A description",
 	owners: [],
 	ownersIds: [UserTest.id],
 	isShared: false,
 	sharingCode: uuidv4(),
 	grantedUsersIds: [User1.id],
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-5),
+	updatedDate: getDateFromNow(-5),
 };
 
 export const ListGranted: List = {
@@ -24,8 +25,8 @@ export const ListGranted: List = {
 	isShared: true,
 	sharingCode: uuidv4(),
 	grantedUsersIds: [UserTest.id],
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-4),
+	updatedDate: getDateFromNow(-4),
 };
 
 export const ListGrantedButNotShared: List = {
@@ -36,8 +37,8 @@ export const ListGrantedButNotShared: List = {
 	isShared: false,
 	sharingCode: uuidv4(),
 	grantedUsersIds: [UserTest.id],
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-3),
+	updatedDate: getDateFromNow(-3),
 };
 
 export const ListInvited: List = {
@@ -48,8 +49,8 @@ export const ListInvited: List = {
 	isShared: true,
 	sharingCode: uuidv4(),
 	grantedUsersIds: [],
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-2),
+	updatedDate: getDateFromNow(-2),
 };
 
 export const ListUnauthorized: List = {
@@ -60,6 +61,6 @@ export const ListUnauthorized: List = {
 	isShared: true,
 	sharingCode: uuidv4(),
 	grantedUsersIds: [],
-	createdDate: new Date(),
-	updatedDate: new Date(),
+	createdDate: getDateFromNow(-1),
+	updatedDate: getDateFromNow(-1),
 };

--- a/api/tests/seeder/seeder.test.ts
+++ b/api/tests/seeder/seeder.test.ts
@@ -4,7 +4,6 @@ import { Factory, Seeder as TSeeder } from "typeorm-seeding";
 import Gift from "../../src/models/Gift";
 import List from "../../src/models/List";
 import User from "../../src/models/User";
-import { UserTest } from "../global";
 import { Gift1, Gift2, Gift3, Gift4, Gift5 } from "./gifts.seed";
 import {
 	ListGranted,
@@ -13,7 +12,7 @@ import {
 	ListOwned,
 	ListUnauthorized,
 } from "./lists.seed";
-import { User1, User2 } from "./users.seed";
+import { User1, User2, UserTest } from "./users.seed";
 
 export default class Seeder implements TSeeder {
 	public async run(_factory: Factory, connection: Connection): Promise<any> {

--- a/api/tests/seeder/users.seed.ts
+++ b/api/tests/seeder/users.seed.ts
@@ -1,15 +1,31 @@
+import { config } from "dotenv";
+import { v4 as uuidv4 } from "uuid";
+
 import { User } from "../../src/models/User";
+import { getDateFromNow } from "./helper";
+
+config({ path: process.env.NODE_ENV == "dev" ? ".env.local" : ".env.test" });
+
+export const UserTest: User = {
+	id: uuidv4(),
+	auth0Id: process.env.AUTH0_CLIENT_ID + "@clients",
+	email: "testuser@test.fr",
+	displayName: "Test User",
+	createdDate: getDateFromNow(),
+};
 
 export const User1: User = {
-	id: "auth0|000000000000000000000000",
+	id: uuidv4(),
+	auth0Id: "auth0|000000000000000000000000",
 	email: "test1@test.fr",
 	displayName: "TestUser1",
-	createdDate: new Date(),
+	createdDate: getDateFromNow(1),
 };
 
 export const User2: User = {
-	id: "facebook|000000000000000000000000",
+	id: uuidv4(),
+	auth0Id: "facebook|000000000000000000000000",
 	email: "test2@test.fr",
 	displayName: "TestUser2",
-	createdDate: new Date(),
+	createdDate: getDateFromNow(2),
 };


### PR DESCRIPTION
@pchatard this PR as a proposal to fix #60, #62 and #74.

It: 
* add a optional `description` string field to List;
* dissociate User `id` from Auth0 ones:
  * `id` prop of User is now an UUID;
  * `auth0Id` prop is created in User, all DB `find`, `update`, etc. are conditionned by `where: { auth0Id: request.userId }` clause;
  * `ownersIds` and `grantedUsersIds` are array of User **id** prop, in consequences neither User mail nor User Auth0 ID are exposed.